### PR TITLE
🐛 Add Debug Logging for Slash Command Sync

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -45,10 +45,12 @@ class Bot(commands.Bot):
 			Logger.error('Failed to get bot user details')
 			return
 		Logger.info('Syncing application commands...')
+		Logger.info(f'Global commands before sync: {[cmd.name for cmd in self.tree.get_commands()]}')  # 🐛 Debug: Global commands
 		for Guild in self.guilds:
 			Logger.info(f'• Syncing commands for guild: {Guild.name} ({Guild.id})')
 			try:
-				await self.tree.sync()
+				await self.tree.sync(guild=Guild)
+				Logger.info(f'Guild commands after sync for {Guild.id}: {[cmd.name for cmd in self.tree.get_commands(guild=Guild)]}')  # 🐛 Debug: Guild-specific commands
 			except Exception as E:
 				Logger.error(f'• Failed to sync commands for guild {Guild.id}: {E}')
 		Logger.info('Done syncing application commands.')


### PR DESCRIPTION
### 🔍 Debug Enhancements for Slash Command Sync

This PR switches back to guild-based sync for faster command availability and adds detailed logging to troubleshoot sync issues.

---

#### 🔄 Reverted to Guild Sync

- Changed from global sync to `await self.tree.sync(guild=Guild)` for immediate command visibility on each server.
- Faster than global sync (no 1-hour wait), but requires bot restart for new servers.

---

#### 📝 Added Debug Logs

- Logs global commands before sync to verify loaded commands.
- Logs guild-specific commands after each sync to confirm successful registration.
- Helps identify why commands like `/gallery` may not appear on certain servers.

---

#### 🛠️ Usage

- Restart the bot and check logs for command lists.
- If `/gallery` is missing, it indicates a loading or definition issue.

---

This resolves sync delays and improves debugging! 🔧🚀