### PR TITLE
🚀 Add GitHub Actions Workflow to Auto-Restart Pterodactyl Bot Server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: 🚀 Deploy & Restart Pterodactyl Bot Server
+
+on:
+  push:
+    branches: ["main"]  # 🟢 Trigger on push to main branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      BOT_API_URL: ${{ secrets.BOT_API_URL }}   # 🔒 Pterodactyl API endpoint (set in repo secrets)
+      BOT_API_KEY: ${{ secrets.BOT_API_KEY }}   # 🔒 Pterodactyl API key (set in repo secrets)
+
+    steps:
+    - name: 🔄 Restart Bot Server via Pterodactyl API
+      run: |
+        # 📨 Send restart signal to Pterodactyl server
+        curl -X POST "${BOT_API_URL}" \
+          -H "Authorization: Bearer ${BOT_API_KEY}" \
+          -H "Content-Type: application/json" \
+          --data '{"signal": "restart"}'


### PR DESCRIPTION
### 🤖 Automated Bot Server Restart on Deploy

This PR introduces a GitHub Actions workflow that automatically restarts the Pterodactyl bot server after every push to the `main` branch.

---

#### 📝 Features

- Triggers on every push to `main` for seamless deployments.
- Uses secure GitHub secrets for the Pterodactyl API endpoint and key.
- Sends a restart signal to the bot server via the Pterodactyl API.
- Includes clear comments and emoji styling for easy understanding.

---

#### ⚡ Benefits

- No more manual restarts after deploying code!
- Keeps your bot running the latest version with zero hassle.

---

Enjoy a smoother and smarter deployment process! 🚀✨